### PR TITLE
Ux patch

### DIFF
--- a/app/components/scatter-plot.js
+++ b/app/components/scatter-plot.js
@@ -87,13 +87,16 @@ ScatterPlot.prototype.render = function () {
       dataKey: 'gasPrice',
       type: 'number',
       name: 'Gas Price',
-      unit: ' gwei'
+      unit: ' gwei',
+      scale: 'sqrt',
+      ticks: [1, 2, 5, 10, 20, 50, 100, 200],
     }),
     h(ZAxis, {
       dataKey: 'count',
       type: 'number',
       name: 'Transaction Count',
-      range: zrange,
+      range: [30, 200],
+      scale: 'linear',
     }),
     h(CartesianGrid),
     h(Scatter, {
@@ -103,9 +106,7 @@ ScatterPlot.prototype.render = function () {
       stackOffset: 'expand',
     }),
     h(Tooltip, {
-      cursor: {
-        strokeDasharray: '20 20',
-      },
+      cursor: false,
     })
   ])
 }

--- a/app/components/scatter-plot.js
+++ b/app/components/scatter-plot.js
@@ -95,7 +95,7 @@ ScatterPlot.prototype.render = function () {
       dataKey: 'count',
       type: 'number',
       name: 'Transaction Count',
-      range: [30, 200],
+      range: [6, 250],
       scale: 'linear',
     }),
     h(CartesianGrid),

--- a/bundle.js
+++ b/bundle.js
@@ -143,7 +143,7 @@ ScatterPlot.prototype.render = function () {
     dataKey: 'count',
     type: 'number',
     name: 'Transaction Count',
-    range: [30, 200],
+    range: [6, 250],
     scale: 'linear'
   }), h(CartesianGrid), h(Scatter, {
     name: 'Recent Transaction Costs',

--- a/bundle.js
+++ b/bundle.js
@@ -136,21 +136,22 @@ ScatterPlot.prototype.render = function () {
     dataKey: 'gasPrice',
     type: 'number',
     name: 'Gas Price',
-    unit: ' gwei'
+    unit: ' gwei',
+    scale: 'sqrt',
+    ticks: [1, 2, 5, 10, 20, 50, 100, 200]
   }), h(ZAxis, {
     dataKey: 'count',
     type: 'number',
     name: 'Transaction Count',
-    range: zrange
+    range: [30, 200],
+    scale: 'linear'
   }), h(CartesianGrid), h(Scatter, {
     name: 'Recent Transaction Costs',
     data: filtered,
     fill: '#888',
     stackOffset: 'expand'
   }), h(Tooltip, {
-    cursor: {
-      strokeDasharray: '20 20'
-    }
+    cursor: false
   })]);
 };
 


### PR DESCRIPTION
played around with it a bit more

before:
<img width="418" alt="screen shot 2018-01-10 at 4 51 45 pm" src="https://user-images.githubusercontent.com/1474978/34803209-e1672004-f626-11e7-9a94-818f412539b3.png">

after:
<img width="410" alt="screen shot 2018-01-10 at 4 52 06 pm" src="https://user-images.githubusercontent.com/1474978/34803208-e15146f8-f626-11e7-877d-d01e13eca5ea.png">

maybe not aesthetically an improvement, but the larger minimum and removing the cursor made for better tooltip functionality

also made the y-axis log-scaled, for a zoomed-in view to the low gasPrices